### PR TITLE
 #167727640 User(manager) can Reject a Request

### DIFF
--- a/src/controllers/RequestController.js
+++ b/src/controllers/RequestController.js
@@ -142,6 +142,36 @@ class RequestController {
       return HelperMethods.clientError(res,
         'No pending request found or request has been previously approved', 404);
     } catch (error) {
+      if (error.errors) return HelperMethods.sequelizeValidationError(res, error);
+      return HelperMethods.serverError(res);
+    }
+  }
+
+  /**
+  * Reject a Request
+  * Route: PATCH: /request/reject
+  * @param {object} req - HTTP Request object
+  * @param {object} res - HTTP Response object
+  * @return {res} res - HTTP Response object
+  * @memberof RequestController
+  */
+  static async rejectRequest(req, res) {
+    try {
+      const requestExist = await Request.findByPk(req.body.id);
+      if (requestExist.dataValues.status === 'open' && requestExist.dataValues.id) {
+        await requestExist.update({ status: 'rejected' });
+        return HelperMethods
+          .requestSuccessful(res, {
+            success: true,
+            message: 'You have successfully rejected this request',
+          }, 200);
+      }
+      return HelperMethods.clientError(
+        res, 'This request has already been rejected',
+        400
+      );
+    } catch (error) {
+      if (error.errors) return HelperMethods.sequelizeValidationError(res, error);
       return HelperMethods.serverError(res);
     }
   }

--- a/src/models/Request.js
+++ b/src/models/Request.js
@@ -51,7 +51,7 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.ENUM,
       values: ['BUSINESS', 'VACATION', 'EXPEDITION'],
       defaultValue: 'BUSINESS'
-    }
+    },
   });
 
   Request.associate = models => {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -181,16 +181,6 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: false
     }
-  },
-  {
-    classMethods: {
-      associate: models => {
-        User.hasMany(models.Request, {
-          foreignKey: 'userId',
-          as: 'users_request',
-        });
-      }
-    }
   });
 
   User.beforeCreate(async user => {

--- a/src/routes/requestRoute.js
+++ b/src/routes/requestRoute.js
@@ -30,6 +30,13 @@ const requestRoutes = app => {
     Authorization.confirmRole,
     RequestController.approveRequest
   );
+
+  app.patch(
+    '/api/v1/request/reject',
+    Authorization.checkToken,
+    Authorization.confirmRole,
+    RequestController.rejectRequest
+  );
 };
 
 export default requestRoutes;

--- a/src/test/integrationTests/userController.test.js
+++ b/src/test/integrationTests/userController.test.js
@@ -41,6 +41,10 @@ describe('Integration tests for the user controller', () => {
     });
   });
   describe('Test to pre-register a user', () => {
+    let stubCreateTokenAndSendEmail;
+    afterEach(() => {
+      if (stubCreateTokenAndSendEmail.restore) stubCreateTokenAndSendEmail.restore();
+    });
     it('should create a user and send email for verification', async () => {
       const userDetails = {
         username: 'JthnDmkloes',
@@ -49,7 +53,7 @@ describe('Integration tests for the user controller', () => {
         firstName: 'John',
         lastName: 'Doe',
       };
-      const stubCreateTokenAndSendEmail = sinon.stub(
+      stubCreateTokenAndSendEmail = sinon.stub(
         UserController, 'createTokenAndSendEmail'
       ).returns(true);
       const response = await chai.request(app).post('/api/v1/auth/signup')
@@ -74,7 +78,7 @@ describe('Integration tests for the user controller', () => {
         firstName: 'Johns',
         lastName: 'Does',
       };
-      const stubCreateTokenAndSendEmail = sinon.stub(
+      stubCreateTokenAndSendEmail = sinon.stub(
         UserController, 'createTokenAndSendEmail'
       ).returns(false);
       const response = await chai.request(app).post('/api/v1/auth/signup')
@@ -87,7 +91,6 @@ describe('Integration tests for the user controller', () => {
       );
       expect(response.body).to.have.property('success');
       expect(response.body.success).to.be.equal(false);
-      stubCreateTokenAndSendEmail.restore();
     });
     it('should return an error when any user details is not given', async () => {
       const userDetails = {

--- a/src/test/unitTests/requestController.test.js
+++ b/src/test/unitTests/requestController.test.js
@@ -28,4 +28,12 @@ describe('unit test for the Request Controller', () => {
     expect(response).to.have.property('success');
     expect(response.success).to.equal(false);
   });
+  it('should only allow managers reject a request', async () => {
+    stubbedMethod = sinon.stub(Request, 'update').throws({ dataValues: 'some thing' });
+    const response = await RequestController.rejectRequest(req, res);
+    expect(response).to.have.property('message');
+    expect(response.message).to.equal('Internal server error');
+    expect(response).to.have.property('success');
+    expect(response.success).to.equal(false);
+  });
 });

--- a/src/utils/ResponseHandler.js
+++ b/src/utils/ResponseHandler.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ *
+ *
+ * @export
+ * @class ResponseHandler
+ */
+export default class ResponseHandler {
+  /**
+   *
+   *
+   * @static
+   * @param {*} res HTTP response object
+   * @param {*} data An object or array to send as a response
+   * @param {number} [status=200] HTTP response status code. Default is 200
+   * @memberof ResponseHandler
+   * @returns {void}
+   */
+  static success(res, data, status = 200) {
+    return res.status(status).json({
+      success: true,
+      status,
+      data
+    });
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {*} res HTTP response object
+   * @param {string} [message='Bad request'] An error message
+   * @param {number} [status=400] HTTP response status code. Default is 400
+   * @memberof ResponseHandler
+   * @returns {void}
+   */
+  static error(res, message = 'Bad request', status = 400) {
+    return res.status(status).json({
+      success: false,
+      status,
+      error: message
+    });
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Ensures that a user(manager) can reject a trip request.

`PATCH /api/v1/request/reject`

#### Description of Task to be completed?
Given that a user is a manager when he logs in,
he should be able to reject a trip request.
Only a manager has the capacity to reject a trip request

#### How should this be manually tested?
* Clone the repo and `cd` into the project directory
* Run `yarn install` to install the project's dependency
* Run `yarn start` to start the app
Login with a manager credential (email and password)
Send a PATCH request to  `localhost:3000/api/v1/request/reject`

#### What are the relevant pivotal tracker stories?
[#167727640](https://www.pivotaltracker.com/story/show/167727640)

#### Any background context you want to add?
None
